### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To run Julia in a Jupyter notebook on your own machine:
 ```
 3. Build Jupyter via
 ```julia
-] bulid IJulia
+] build IJulia
 ```
 4. Launch Jupyter by typing
 ```julia


### PR DESCRIPTION
I think in the installation, it should say `build IJulia` instead of `bulid IJulia`.