### PR TITLE
fixed typo in the solution for Q4 in sheet 4

### DIFF
--- a/sheets/sheet4s.tex
+++ b/sheets/sheet4s.tex
@@ -267,7 +267,7 @@ where we assume  that $h = 2^{-n}$ for $n \ensuremath{\leq} S$.
 
 In floating point we have
 \begin{align*}
-{f^{\rm FP}(x + 2h) \ensuremath{\ominus} f^{\rm FP}(x-2h) \over 2h} &= {f(x + h) +  \ensuremath{\delta}_{x+h} - f(x-h) - \ensuremath{\delta}_{x-h} \over 2h} (1 + \ensuremath{\delta}_1) \\
+{f^{\rm FP}(x + h) \ensuremath{\ominus} f^{\rm FP}(x-h) \over 2h} &= {f(x + h) +  \ensuremath{\delta}_{x+h} - f(x-h) - \ensuremath{\delta}_{x-h} \over 2h} (1 + \ensuremath{\delta}_1) \\
 &= {f(x+h) - f(x-h) \over 2h} (1 + \ensuremath{\delta}_1) + {\ensuremath{\delta}_{x+h}- \ensuremath{\delta}_{x-h} \over 2h} (1 + \ensuremath{\delta}_1)
 \end{align*}
 Applying Taylor's theorem we get

--- a/src/sheets/sheet4s.jmd
+++ b/src/sheets/sheet4s.jmd
@@ -156,7 +156,7 @@ where we assume  that $h = 2^{-n}$ for $n ≤ S$.
 In floating point we have
 $$
 \begin{align*}
-{f^{\rm FP}(x + 2h) ⊖ f^{\rm FP}(x-2h) \over 2h} &= {f(x + h) +  δ_{x+h} - f(x-h) - δ_{x-h} \over 2h} (1 + δ_1) \\
+{f^{\rm FP}(x + h) ⊖ f^{\rm FP}(x-h) \over 2h} &= {f(x + h) +  δ_{x+h} - f(x-h) - δ_{x-h} \over 2h} (1 + δ_1) \\
 &= {f(x+h) - f(x-h) \over 2h} (1 + δ_1) + {δ_{x+h}- δ_{x-h} \over 2h} (1 + δ_1)
 \end{align*}
 $$


### PR DESCRIPTION
In the solution there was a typo 
<img width="789" alt="image" src="https://github.com/Imperial-MATH50003/MATH50003NumericalAnalysis/assets/21164792/aec807de-c560-407d-8ef2-6d40d6b74131">
I think that should be x+h instead of x+2h